### PR TITLE
Remove 'game' field from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -36,13 +36,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: game
-    attributes:
-      label: Which game did this occur on?
-      description: Please tell us the name of the game. If it's a personal or private project, just let us know the Unity version.
-    validations:
-      required: true
-  - type: textarea
     id: what-happened
     attributes:
       label: Describe the issue.


### PR DESCRIPTION
The 'game' field was removed from the bug report template as it is no longer required. This simplifies the template and makes it easier for users to file reports.